### PR TITLE
fix: resolve drag to create folder

### DIFF
--- a/LaunchNow/LaunchpadView.swift
+++ b/LaunchNow/LaunchpadView.swift
@@ -1769,8 +1769,16 @@ extension LaunchpadView {
     
     private func handleAppHover(dragging: LaunchpadItem, targetApp: AppInfo, hoveringIndex: Int, isInCenterArea: Bool) {
         if dragging == .app(targetApp) {
-            clearHoveringState()
-            pendingDropIndex = hoveringIndex
+            // Hovering over ourselves due to reorder shifting the dragged item into this slot.
+            // Look up the ORIGINAL item at this grid position so folder creation still works.
+            if filteredItems.indices.contains(hoveringIndex),
+               case .app(let originalApp) = filteredItems[hoveringIndex],
+               originalApp.id != targetApp.id {
+                handleAppToAppHover(hoveringIndex: hoveringIndex, isInCenterArea: isInCenterArea, targetApp: originalApp)
+            } else {
+                clearHoveringState()
+                pendingDropIndex = hoveringIndex
+            }
         } else if case .app = dragging {
             handleAppToAppHover(hoveringIndex: hoveringIndex, isInCenterArea: isInCenterArea, targetApp: targetApp)
         } else {


### PR DESCRIPTION
 拖曳排序會將被拖曳的 item 插入到目標位置，導致 currentItems[hoveringIndex]                                                          
 變成自己，原本的邏輯直接 clearHoveringState() 放棄偵測，使得資料夾建立永遠無法觸發。                                                
                                                                                                                                      
 修復方式：當偵測到 hover 到自己時，改為查找 filteredItems（排序前的原始排列）                                                     
 中該位置的 item，若為不同的 app 則繼續走資料夾建立流程。