### PR TITLE
feat: right click add to folder

### DIFF
--- a/LaunchNow/LaunchpadView.swift
+++ b/LaunchNow/LaunchpadView.swift
@@ -1134,6 +1134,19 @@ extension LaunchpadView {
             .frame(height: appHeight)
             // 保持稳定的视图身份，避免在文件夹更新后中断拖拽手势
             .id(item.id)
+            .contextMenu {
+                if case .app(let app) = item, !appStore.folders.isEmpty {
+                    Menu(NSLocalizedString("MoveToFolder", comment: "Move to folder")) {
+                        ForEach(appStore.folders) { folder in
+                            Button(action: {
+                                appStore.addAppToFolder(app, folder: folder)
+                            }) {
+                                Label(folder.name, systemImage: "folder")
+                            }
+                        }
+                    }
+                }
+            }
 
             // Use @ViewBuilder conditional instead of AnyView to allow SwiftUI structural diffing
             if appStore.searchText.isEmpty && !isFolderOpen {

--- a/en.lproj/Localizable.strings
+++ b/en.lproj/Localizable.strings
@@ -67,3 +67,4 @@
 "NoHiddenApps" = "No hidden apps";
 "Hide" = "Hide";
 "ClearHiddenApps" = "Clear hidden";
+"MoveToFolder" = "Move to Folder";

--- a/zh-Hans.lproj/Localizable.strings
+++ b/zh-Hans.lproj/Localizable.strings
@@ -73,3 +73,4 @@
 "NoHiddenApps" = "暂无隐藏应用";
 "Hide" = "隐藏";
 "ClearHiddenApps" = "清空隐藏";
+"MoveToFolder" = "移动到文件夹";


### PR DESCRIPTION
### 說明：
目前要把 APP 加到現有資料夾，只能透過拖曳，但拖曳過程中會把其他圖示擠開，體驗不佳。新增右鍵選單讓使用者可以直接選擇目標資料夾，不需要拖曳。

###  改動總結：
  1. `LaunchpadView.swift` — 在 APP 按鈕上加了 `.contextMenu`，右鍵會出現「Move to Folder」子選單，列出所有現有資料夾
  2. `en.lproj/Localizable.strings` — 加了 "MoveToFolder" = "Move to Folder";
  3. `zh-Hans.lproj/Localizable.strings` — 加了 "MoveToFolder" = "移动到文件夹";
<img width="1920" height="1080" alt="Screenshot 2026-02-22 at 23 04 11" src="https://github.com/user-attachments/assets/4db382b1-3740-4381-91a0-7e1b9cbb0f7e" />
